### PR TITLE
fix(ui): load premium global styles via app/layout + enforce container and classes

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,7 +17,7 @@ export default function DashboardPage() {
       <h1 className="h1">{t('dashboard.title')}</h1>
       {params.has('score') && (
         <Card>
-          <h2>{t('summary.title')}</h2>
+          <h2 className="h2">{t('summary.title')}</h2>
           <p>{t('summary.score')}: {score}/30</p>
           <p>{t('summary.accuracy')}: {Math.round((score / 30) * 100)}%</p>
           <p>{t('summary.time')}: {time}s</p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+// Premium UI: ensure global styles are loaded from /styles.
 import '../styles/globals.css';
 import type { ReactNode } from 'react';
 
@@ -9,7 +10,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="it">
-      <body>
+      <body className="container">
         {children}
         <nav className="tabbar">
           <a href="/">Home</a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,12 @@
 import Button from '../components/Button';
-import { BuddyBook } from '../components/BuddyIllustration';
+import { Buddy } from '../components/BuddyIllustration';
 import { t } from '../lib/i18n';
 
 export default function HomePage() {
   return (
     <main className="container" style={{ paddingBottom: 72, textAlign: 'center' }}>
-      <BuddyBook width={120} className="img-center" />
-      <h1 className="h1">{t('home.title')}</h1>
+      <Buddy width={120} className="img-center" />
+      <h1 className="h0">{t('home.title')}</h1>
       <p className="lead">{t('home.subtitle')}</p>
       <Button href="/auth">{t('home.cta_start_session')}</Button>
     </main>

--- a/app/paywall/page.tsx
+++ b/app/paywall/page.tsx
@@ -25,12 +25,12 @@ export default function PaywallPage() {
     <main className="container" style={{ paddingBottom: 72 }}>
       <h1 className="h1">Scegli il tuo piano</h1>
       <Card>
-        <h2>Premium</h2>
+        <h2 className="h2">Premium</h2>
         <p>7 quiz al giorno</p>
         <Button onClick={() => checkout('premium')}>Iscriviti</Button>
       </Card>
       <Card>
-        <h2>Pro</h2>
+        <h2 className="h2">Pro</h2>
         <p>Quiz illimitati</p>
         <Button onClick={() => checkout('pro')}>Iscriviti</Button>
       </Card>

--- a/components/BuddyIllustration.tsx
+++ b/components/BuddyIllustration.tsx
@@ -3,7 +3,7 @@ import { SVGProps } from 'react';
 export function Buddy(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 64 64" {...props}>
-      <circle cx="32" cy="32" r="32" fill="#2ecc71" />
+      <circle cx="32" cy="32" r="32" fill="#176d46" />
       <circle cx="24" cy="26" r="6" fill="#fff" />
       <circle cx="40" cy="26" r="6" fill="#fff" />
       <path d="M20 44c4 4 20 4 24 0" stroke="#fff" strokeWidth="4" fill="none" />
@@ -14,7 +14,7 @@ export function Buddy(props: SVGProps<SVGSVGElement>) {
 export function BuddyBook(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 64 64" {...props}>
-      <rect x="8" y="12" width="48" height="40" rx="4" fill="#2ecc71" />
+      <rect x="8" y="12" width="48" height="40" rx="4" fill="#176d46" />
       <line x1="32" y1="12" x2="32" y2="52" stroke="#fff" strokeWidth="2" />
     </svg>
   );
@@ -23,7 +23,7 @@ export function BuddyBook(props: SVGProps<SVGSVGElement>) {
 export function BuddyThinking(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 64 64" {...props}>
-      <circle cx="32" cy="32" r="32" fill="#2ecc71" />
+      <circle cx="32" cy="32" r="32" fill="#176d46" />
       <circle cx="24" cy="26" r="6" fill="#fff" />
       <circle cx="40" cy="26" r="6" fill="#fff" />
       <path d="M20 44c12 -8 24 0 24 0" stroke="#fff" strokeWidth="4" fill="none" />
@@ -34,8 +34,8 @@ export function BuddyThinking(props: SVGProps<SVGSVGElement>) {
 export function BuddyAvatar(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 64 64" {...props}>
-      <circle cx="32" cy="24" r="16" fill="#2ecc71" />
-      <rect x="8" y="40" width="48" height="16" rx="8" fill="#2ecc71" />
+      <circle cx="32" cy="24" r="16" fill="#176d46" />
+      <rect x="8" y="40" width="48" height="16" rx="8" fill="#176d46" />
     </svg>
   );
 }

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -22,7 +22,7 @@ export default function Button({
   style,
   className,
 }: Props) {
-  const base = variant === 'primary' ? 'btn' : 'btn secondary';
+  const base = variant === 'primary' ? 'btn btn-primary' : 'btn secondary';
   const cls = className ? base + ' ' + className : base;
   if (href) {
     return (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,6 @@
 *{box-sizing:border-box}
 :root{
-  --color-brand:#2ecc71;
+  --color-brand:#176d46;
   --color-ink:#ffffff;
   --color-bg:#ffffff;
   --color-text:#111111;
@@ -13,9 +13,11 @@ button{cursor:pointer;font-family:inherit}
 .container{width:100%;max-width:430px;margin:0 auto;padding:16px}
 .h0{font-size:2rem;font-weight:700;margin:0 0 16px}
 .h1{font-size:1.5rem;font-weight:700;margin:0 0 12px}
+.h2{font-size:1.25rem;font-weight:700;margin:0 0 8px}
 .lead{font-size:1rem;margin:0 0 16px;color:#555}
 .card{background:#fff;border:1px solid var(--color-line);border-radius:12px;padding:16px;margin-bottom:16px}
-.btn{display:inline-block;background:var(--color-brand);color:var(--color-ink);border:none;border-radius:8px;padding:12px 16px;font-weight:600;text-align:center}
+.btn{display:inline-block;border:none;border-radius:8px;padding:12px 16px;font-weight:600;text-align:center}
+.btn-primary{background:var(--color-brand);color:var(--color-ink)}
 .btn.secondary{background:var(--color-muted);color:var(--color-text)}
 .tabbar{position:fixed;left:0;right:0;bottom:0;display:flex;justify-content:space-around;padding:8px 0;background:#fff;border-top:1px solid var(--color-line)}
 .tabbar a{flex:1;text-align:center;font-size:14px}


### PR DESCRIPTION
## Summary
- ensure layout imports global styles from /styles and wraps content in container
- add missing premium CSS utilities and brand color
- reinforce premium classes across pages

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f37ff10488332a596be586e6c5eb4