### PR TITLE
feat(ui): pixel-perfect quiz flow with session store and summary

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Buddy from '../components/Buddy';
 import Button from '../components/Button';
-import { Buddy } from '../components/BuddyIllustration';
-import { t } from '../lib/i18n';
+import CourseSubjectPicker, { PickerChange } from '../components/CourseSubjectPicker';
+import { useSessionStore } from '../store/useSessionStore';
+import { useUserStore } from '../store/useUserStore';
 
 export default function HomePage() {
+  const router = useRouter();
+  const startSession = useSessionStore((s) => s.startSession);
+  const canUseQuiz = useUserStore((s) => s.canUseQuiz);
+  const [sel, setSel] = useState<PickerChange>({ course: '', subject: '' });
+
+  const start = () => {
+    if (!canUseQuiz()) {
+      alert('Limite raggiunto');
+      return;
+    }
+    if (!sel.course || !sel.subject) return;
+    startSession(sel.course, sel.subject);
+    router.push('/quiz');
+  };
+
   return (
     <main className="container" style={{ paddingBottom: 72, textAlign: 'center' }}>
-      <Buddy width={120} className="img-center" />
-      <h1 className="h0">{t('home.title')}</h1>
-      <p className="lead">{t('home.subtitle')}</p>
-      <Button href="/auth">{t('home.cta_start_session')}</Button>
+      <h1 className="h0" style={{ fontSize: 34, marginTop: 64 }}>Allenati con Buddy</h1>
+      <Buddy className="w-40 h-40 mx-auto my-4" />
+      <p className="lead">Puoi provare gratis un quiz completo</p>
+      <CourseSubjectPicker onChange={setSel} />
+      <Button onClick={start} style={{ marginTop: 16 }}>Inizia subito</Button>
     </main>
   );
 }

--- a/app/quiz/summary/page.tsx
+++ b/app/quiz/summary/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Button from '../../../components/Button';
+import { useSessionStore } from '../../../store/useSessionStore';
+
+export default function SummaryPage() {
+  const router = useRouter();
+  const { session, resetSession } = useSessionStore((s) => ({
+    session: s.session,
+    resetSession: s.resetSession,
+  }));
+
+  if (session.status !== 'ended') return null;
+
+  const duration = session.startedAt && session.endedAt
+    ? Math.round((session.endedAt - session.startedAt) / 1000)
+    : 0;
+
+  return (
+    <main className="container" style={{ paddingBottom: 72, textAlign: 'center' }}>
+      <h1 className="h0" style={{ fontSize: 34 }}>Esame terminato</h1>
+      <p className="lead">
+        {session.course} · {session.subject} · durata {duration}s · domande {session.items.length}
+      </p>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {session.items.map((it, idx) => (
+          <li key={it.id} className="card" style={{ marginBottom: 8 }}>
+            #{idx + 1} — {it.predicted} ({Math.round(it.confidence * 100)}%)
+          </li>
+        ))}
+      </ul>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <Button
+          onClick={() => {
+            resetSession();
+            router.push('/');
+          }}
+        >
+          Nuova sessione
+        </Button>
+        <Button variant="secondary" onClick={() => router.push('/dashboard')}>
+          Vai ai Progressi
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/components/Buddy.tsx
+++ b/components/Buddy.tsx
@@ -1,0 +1,21 @@
+export default function Buddy({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <circle cx="32" cy="32" r="32" fill="#176d46" />
+      <circle cx="24" cy="26" r="6" fill="#fff" />
+      <circle cx="40" cy="26" r="6" fill="#fff" />
+      <path
+        d="M20 44c4 4 20 4 24 0"
+        stroke="#fff"
+        strokeWidth="4"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/components/CameraCapture.tsx
+++ b/components/CameraCapture.tsx
@@ -2,14 +2,31 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Button from './Button';
+import { useUserStore } from '../store/useUserStore';
 
 interface Props {
-  onCapture(blob: Blob): void;
+  onCapture?: (blob: Blob) => void;
+  onAnalyzed?: (r: {
+    predicted: 'A' | 'B' | 'C' | 'D';
+    confidence: number;
+    latencyMs: number;
+  }) => void;
+  showResultCard?: boolean;
+  ctaLabel?: string;
 }
 
-export default function CameraCapture({ onCapture }: Props) {
+export default function CameraCapture({
+  onCapture,
+  onAnalyzed,
+  showResultCard = true,
+  ctaLabel,
+}: Props) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [hasPermission, setHasPermission] = useState(false);
+  const [result, setResult] = useState<
+    | { predicted: 'A' | 'B' | 'C' | 'D'; confidence: number; latencyMs: number }
+    | null
+  >(null);
 
   useEffect(() => {
     async function init() {
@@ -35,13 +52,42 @@ export default function CameraCapture({ onCapture }: Props) {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.drawImage(video, 0, 0);
-    canvas.toBlob((blob) => blob && onCapture(blob), 'image/png');
+    canvas.toBlob(async (blob) => {
+      if (!blob) return;
+      if (onAnalyzed) {
+        const { canUseQuiz } = useUserStore.getState();
+        if (!canUseQuiz()) {
+          alert('Limite raggiunto');
+          return;
+        }
+        const base64 = await toBase64(blob);
+        const t0 = performance.now();
+        const res = await fetch('/api/analyze', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ imageBase64: base64.split(',')[1] }),
+        });
+        const data = await res.json();
+        const latency = performance.now() - t0;
+        const r = {
+          predicted: data.predicted as 'A' | 'B' | 'C' | 'D',
+          confidence: data.confidence ?? 0,
+          latencyMs: latency,
+        };
+        setResult(r);
+        onAnalyzed(r);
+      } else {
+        onCapture && onCapture(blob);
+      }
+    }, 'image/png');
   };
 
   const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) onCapture(file);
+    if (file) onCapture?.(file);
   };
+
+  const label = ctaLabel ?? (onAnalyzed ? 'Scatta & Analizza' : 'Scatta');
 
   if (!hasPermission) {
     return (
@@ -54,7 +100,21 @@ export default function CameraCapture({ onCapture }: Props) {
   return (
     <div>
       <video ref={videoRef} autoPlay playsInline style={{ width: '100%' }} />
-      <Button onClick={takePhoto} style={{ marginTop: 8 }}>Scatta</Button>
+      <Button onClick={takePhoto} style={{ marginTop: 8 }}>{label}</Button>
+      {result && showResultCard && (
+        <div className="card" style={{ textAlign: 'center', marginTop: 16 }}>
+          <p>Risposta corretta: {result.predicted}</p>
+          <small>Confidenza {(result.confidence * 100).toFixed(1)}%</small>
+        </div>
+      )}
     </div>
   );
+}
+
+function toBase64(blob: Blob): Promise<string> {
+  return new Promise((res) => {
+    const r = new FileReader();
+    r.onload = () => res(r.result as string);
+    r.readAsDataURL(blob);
+  });
 }

--- a/components/CourseSubjectPicker.tsx
+++ b/components/CourseSubjectPicker.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type PickerChange = { course: string; subject: string };
+
+export default function CourseSubjectPicker({
+  defaultCourse,
+  defaultSubject,
+  onChange,
+}: {
+  defaultCourse?: string;
+  defaultSubject?: string;
+  onChange?: (v: PickerChange) => void;
+}) {
+  const [course, setCourse] = useState(defaultCourse ?? '');
+  const [subject, setSubject] = useState(defaultSubject ?? '');
+
+  useEffect(() => {
+    onChange?.({ course, subject });
+  }, [course, subject, onChange]);
+
+  const courses = ['Informatica', 'Ingegneria', 'Economia'];
+  const subjects = ['Algoritmi', 'Reti', 'Diritto', 'Statistica'];
+
+  return (
+    <div className="card" style={{ textAlign: 'left' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <label>
+          <span>Corso di Laurea</span>
+          <select
+            value={course}
+            onChange={(e) => setCourse(e.target.value)}
+            className="input"
+          >
+            <option value="">Seleziona</option>
+            {courses.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Materia</span>
+          <select
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            className="input"
+          >
+            <option value="">Seleziona</option>
+            {subjects.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/store/useSessionStore.ts
+++ b/store/useSessionStore.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+
+export type SessionStatus = 'idle' | 'running' | 'ended';
+export type QuizItem = {
+  id: string;
+  predicted: 'A' | 'B' | 'C' | 'D';
+  confidence: number;
+  latencyMs: number;
+};
+export type Session = {
+  status: SessionStatus;
+  course?: string;
+  subject?: string;
+  items: QuizItem[];
+  startedAt?: number;
+  endedAt?: number;
+};
+
+const initialState: Session = { status: 'idle', items: [] };
+
+type Store = {
+  session: Session;
+  startSession(course: string, subject: string): void;
+  appendResult(item: QuizItem): void;
+  endSession(): void;
+  resetSession(): void;
+};
+
+export const useSessionStore = create<Store>((set) => ({
+  session: initialState,
+  startSession: (course, subject) =>
+    set({
+      session: {
+        status: 'running',
+        course,
+        subject,
+        items: [],
+        startedAt: Date.now(),
+      },
+    }),
+  appendResult: (item) =>
+    set((s) =>
+      s.session.status === 'running'
+        ? { session: { ...s.session, items: [...s.session.items, item] } }
+        : { session: s.session }
+    ),
+  endSession: () =>
+    set((s) => ({
+      session:
+        s.session.status === 'running'
+          ? { ...s.session, status: 'ended', endedAt: Date.now() }
+          : s.session,
+    })),
+  resetSession: () => set({ session: initialState }),
+}));

--- a/store/useUserStore.ts
+++ b/store/useUserStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Usage, quizzesLeft } from '../lib/quotas';
+
+export type Plan = 'free' | 'premium' | 'pro';
+
+interface State {
+  plan: Plan;
+  usage: Usage;
+  canUseQuiz: () => boolean;
+  recordUsage: () => void;
+}
+
+export const useUserStore = create<State>()(
+  persist(
+    (set, get) => ({
+      plan: 'free',
+      usage: { total: 0, daily: { date: '', count: 0 } },
+      canUseQuiz: () => {
+        const { plan, usage } = get();
+        return quizzesLeft(plan, usage) > 0;
+      },
+      recordUsage: () =>
+        set((s) => {
+          const today = new Date().toISOString().slice(0, 10);
+          const daily =
+            s.usage.daily.date === today
+              ? { date: today, count: s.usage.daily.count + 1 }
+              : { date: today, count: 1 };
+          return { usage: { total: s.usage.total + 1, daily } };
+        }),
+    }),
+    { name: 'user-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- implement transient session store and user quota tracking
- add Buddy mascot and course/subject picker components
- overhaul quiz pages with camera capture, answer flow, and summary screen

## Testing
- `npm run build`
- `npm run typecheck`
- `npm run lint` *(fails: Next.js prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f4cd2d1fc8332af6789a2dec02c23