### PR TITLE
feat: polish UI to match mocks

### DIFF
--- a/app/(tabs)/account/page.tsx
+++ b/app/(tabs)/account/page.tsx
@@ -21,11 +21,11 @@ export default function AccountPage() {
             <div className="text-neutral-600">Piano</div>
             <div className="text-[17px] font-medium">Premium</div>
           </div>
-          <a className="text-[#176d46] font-medium" href="/paywall">Gestisci abbonamento ›</a>
+          <a className="text-brand font-medium" href="/paywall">Gestisci abbonamento ›</a>
         </div>
       </div>
 
-      <div className="card p-4"><a className="text-[#176d46] font-medium" href="mailto:hello@example.com">Contattaci</a></div>
+      <div className="card p-4"><a className="text-brand font-medium" href="mailto:hello@example.com">Contattaci</a></div>
       <div className="text-center text-red-600 font-semibold">Esci</div>
     </div>
   );

--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -2,7 +2,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Buddy from '@/components/Buddy';
-import Button from '@/components/Button';
 import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
 import { useSessionStore } from '@/store/useSessionStore';
 import { useUserStore } from '@/store/useUserStore';
@@ -27,7 +26,7 @@ export default function HomePage() {
         <h1 className="h1">Allenati con<br/>Buddy</h1>
       </header>
 
-      <Buddy className="w-48 h-48 mx-auto" />
+      <Buddy className="w-48 h-48 mx-auto" variant="happy" />
 
       <p className="sub text-center">Puoi provare gratis un quiz completo</p>
 
@@ -35,8 +34,8 @@ export default function HomePage() {
         <CourseSubjectPicker onChange={setSel} />
       </div>
 
-      <Button onClick={start} className="w-full">Inizia subito</Button>
-      <div className="h-20" /> {/* spazio sopra la bottom-nav */}
+      <button onClick={start} className="btn-hero w-full">Inizia subito</button>
+      <div className="h-20" />
     </div>
   );
 }

--- a/app/(tabs)/progress/page.tsx
+++ b/app/(tabs)/progress/page.tsx
@@ -2,7 +2,7 @@
 function Bar({ value }:{value:number}) {
   return (
     <div className="h-3 rounded-full bg-neutral-200 overflow-hidden">
-      <div className="h-full bg-[#176d46]" style={{ width: `${Math.min(100, Math.max(0, value))}%` }} />
+      <div className="h-full bg-brand" style={{ width: `${Math.min(100, Math.max(0, value))}%` }} />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,18 +3,20 @@
 @tailwind utilities;
 
 :root { color-scheme: light; }
-
 html, body { height: 100%; }
 body { @apply bg-neutral-50 text-neutral-900 antialiased; }
 
 .container-app { @apply max-w-md mx-auto min-h-screen bg-white; }
 
 .card { @apply rounded-2xl border border-neutral-200 bg-white shadow-sm; }
-.btn { @apply inline-flex items-center justify-center rounded-2xl font-medium active:scale-[0.99] transition; }
-.btn-hero { @apply btn h-14 px-6 text-base bg-[#176d46] text-white; }
-.btn-ghost { @apply btn h-12 px-4 bg-neutral-200 text-neutral-800; }
-.btn-outline { @apply btn h-12 px-4 border border-neutral-300 bg-white text-neutral-800; }
 
-.h1 { @apply text-5xl leading-tight font-semibold; }
+.btn       { @apply inline-flex items-center justify-center rounded-2xl font-medium active:scale-[0.99] transition; }
+.btn-hero  { @apply btn h-14 px-6 text-base bg-brand text-white; }
+.btn-ghost { @apply btn h-12 px-4 bg-neutral-200 text-neutral-800; }
+.btn-line  { @apply btn h-12 px-4 border border-neutral-300 bg-white text-neutral-800; }
+
+.h1 { @apply text-6xl leading-tight font-semibold; }     /* ~60px */
 .h2 { @apply text-3xl font-semibold; }
 .sub { @apply text-[18px] leading-6 text-neutral-700; }
+
+.nav-safe-bottom { height: calc(56px + env(safe-area-inset-bottom)); }

--- a/app/paywall/page.tsx
+++ b/app/paywall/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 import Buddy from '@/components/Buddy';
-import Button from '@/components/Button';
 
 export default function PaywallPage() {
   return (
     <div className="container-app p-4 space-y-6">
       <h1 className="h2 text-center">Passa a Premium<br/>per continuare</h1>
-      <Buddy className="w-44 h-44 mx-auto" />
+      <Buddy className="w-44 h-44 mx-auto" variant="tablet" />
       <ul className="space-y-2 text-[18px]">
         <li>✓ Quiz illimitati</li>
         <li>✓ Statistiche avanzate</li>
@@ -21,7 +20,7 @@ export default function PaywallPage() {
           <div className="text-2xl font-semibold">€10/m</div>
         </div>
       </div>
-      <Button className="w-full">Prosegui</Button>
+      <button className="btn-hero w-full">Prosegui</button>
     </div>
   );
 }

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Buddy from '@/components/Buddy';
 import CameraCapture from '@/components/CameraCapture';
-import Button from '@/components/Button';
 import { useSessionStore, QuizItem } from '@/store/useSessionStore';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -12,28 +11,26 @@ type R = { predicted: 'A'|'B'|'C'|'D'; confidence: number; latencyMs: number };
 export default function QuizPage() {
   const router = useRouter();
   const appendResult = useSessionStore(s => s.appendResult);
-  const endSession = useSessionStore(s => s.endSession);
-  const recordUsage = useUserStore(s => s.recordUsage);
+  const endSession   = useSessionStore(s => s.endSession);
+  const recordUsage  = useUserStore(s => s.recordUsage);
   const [last, setLast] = useState<R | null>(null);
   const [thinking, setThinking] = useState(false);
 
   const onAnalyzed = (r: R) => { setThinking(false); setLast(r); };
-  const onSnap = () => { setThinking(true); };
-
   const proceed = () => {
     if (!last) return;
     const item: QuizItem = { id: crypto.randomUUID(), ...last };
     appendResult(item); recordUsage(); setLast(null);
   };
   const finish = () => {
-    if (last) { appendResult({ id: crypto.randomUUID(), ...last }); }
+    if (last) appendResult({ id: crypto.randomUUID(), ...last });
     endSession(); router.push('/quiz/summary');
   };
 
   return (
     <div className="container-app p-4 space-y-6">
       <header className="text-center mt-4"><h1 className="h2">Quiz</h1></header>
-      <Buddy className="w-44 h-44 mx-auto" />
+      <Buddy className="w-44 h-44 mx-auto" variant={thinking ? 'thinking' : 'happy'} />
 
       {!last ? (
         <>
@@ -42,16 +39,14 @@ export default function QuizPage() {
             showResultCard={false}
             ctaLabel="Scatta foto"
             onAnalyzed={onAnalyzed}
-            onStart={onSnap}
-            // piccolo hack: quando parte lo scatto, setta thinking
-            // (basta collegarlo al click del bottone del componente)
+            onStart={() => setThinking(true)}
           />
         </>
       ) : (
         <div className="space-y-4">
           <p className="text-center text-2xl font-semibold">Risposta corretta: {last.predicted}</p>
-          <Button onClick={proceed} className="w-full">Procedi</Button>
-          <Button onClick={finish} variant="ghost" className="w-full">Termina esame</Button>
+          <button onClick={proceed} className="btn-hero w-full">Procedi</button>
+          <button onClick={finish} className="btn-ghost w-full">Termina esame</button>
         </div>
       )}
     </div>

--- a/app/quiz/summary/page.tsx
+++ b/app/quiz/summary/page.tsx
@@ -1,18 +1,17 @@
 'use client';
 import Buddy from '@/components/Buddy';
-import Button from '@/components/Button';
 import { useRouter } from 'next/navigation';
 import { useSessionStore } from '@/store/useSessionStore';
 
 export default function SummaryPage() {
   const router = useRouter();
-  const { items, course, subject, startedAt, endedAt, resetSession } = useSessionStore();
+  const { items, startedAt, endedAt, resetSession } = useSessionStore();
   const duration = startedAt && endedAt ? Math.max(1, Math.round((endedAt - startedAt)/1000)) : 0;
 
   return (
     <div className="container-app p-4 space-y-5">
       <h1 className="h2 text-center">Esame completato</h1>
-      <Buddy className="w-40 h-40 mx-auto" />
+      <Buddy className="w-40 h-40 mx-auto" variant="medal" />
 
       <div className="card p-4">
         <div className="grid grid-cols-2 gap-y-2 text-[17px]">
@@ -23,10 +22,10 @@ export default function SummaryPage() {
         </div>
       </div>
 
-      <Button className="w-full">Rivedi errori</Button>
+      <button className="btn-hero w-full">Rivedi errori</button>
       <div className="grid grid-cols-2 gap-3">
-        <Button variant="outline">Condividi</Button>
-        <Button variant="outline" onClick={() => { resetSession(); router.push('/'); }}>Nuova se</Button>
+        <button className="btn-line">Condividi</button>
+        <button className="btn-line" onClick={() => { resetSession(); router.push('/'); }}>Nuova se</button>
       </div>
     </div>
   );

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -12,21 +12,16 @@ const items = [
 export default function BottomNav() {
   const pathname = usePathname();
   return (
-    <nav className="fixed bottom-0 inset-x-0 z-50">
-      <div className="mx-auto max-w-md backdrop-blur bg-white/95 border-t border-neutral-200">
-        <div className="grid grid-cols-3 px-2 py-2.5">
-          {items.map((it) => {
+    <nav className="fixed bottom-0 left-0 right-0 z-50">
+      <div className="mx-auto max-w-md bg-white/95 backdrop-blur border-t border-neutral-200 nav-safe-bottom">
+        <div className="grid grid-cols-3 px-2 pt-2.5">
+          {items.map(it => {
             const active = pathname === it.href;
             return (
-              <Link
-                key={it.href}
-                href={it.href}
-                className={clsx(
-                  'flex flex-col items-center gap-1 py-1 rounded-xl',
-                  active ? 'text-[#176d46] font-medium' : 'text-neutral-700'
-                )}
-              >
-                <svg className="w-6 h-6" aria-hidden><use href={`/icons.svg#${it.icon}`} /></svg>
+              <Link key={it.href} href={it.href}
+                className={clsx('flex flex-col items-center gap-1 py-1 rounded-xl',
+                  active ? 'text-brand font-medium' : 'text-neutral-700')}>
+                <svg className="w-6 h-6" aria-hidden><use href={`/icons.svg#${it.icon}`}/></svg>
                 <span className="text-xs">{it.label}</span>
               </Link>
             );

--- a/components/Buddy.tsx
+++ b/components/Buddy.tsx
@@ -1,24 +1,40 @@
-export default function Buddy({ className = '' }: { className?: string }) {
+type Variant = 'happy'|'thinking'|'medal'|'tablet'|'book';
+
+export default function Buddy({ className = '', variant = 'happy' }: { className?: string; variant?: Variant }) {
+  // Semplice switch su occhi/bocca e piccoli accessori per rispettare i mock
+  const eyes = variant === 'thinking' ? { cy: 118, r: 3 } : { cy: 116, r: 7 };
   return (
     <svg viewBox="0 0 256 256" className={className} aria-hidden>
-      <g fill="none" stroke="none">
-        <ellipse cx="128" cy="210" rx="52" ry="14" fill="#000" opacity=".06"/>
-        <g>
-          <path fill="#E79A3A" d="M64 82c6-14 28-22 46-18 7 2 12 7 14 13 2-6 7-11 14-13 18-4 40 4 46 18 3 7 0 14-8 18-12 6-28 3-40-7-3-3-5-6-6-9-1 3-3 6-6 9-12 10-28 13-40 7-8-4-11-11-8-18z"/>
-          <path fill="#E79A3A" d="M64 118c0-28 27-50 64-50s64 22 64 50-27 66-64 66-64-38-64-66z"/>
-          <path fill="#D5832E" d="M92 178c0-7 16-10 36-10s36 3 36 10v12H92v-12z"/>
-        </g>
-        <g fill="#111">
-          <circle cx="108" cy="116" r="7"/><circle cx="148" cy="116" r="7"/>
-          <path d="M112 140c8 8 24 8 32 0 4-4 9 2 6 6-12 12-32 12-44 0-3-4 2-10 6-6z"/>
-          <circle cx="128" cy="130" r="4" fill="#8B3A20"/>
-        </g>
-        <g fill="#D5832E">
-          <path d="M84 94c-12-4-18-12-18-18 0-6 6-9 12-7 11 4 16 12 16 20-4 0-6 0-10-2z"/>
-          <path d="M172 94c12-4 18-12 18-18 0-6-6-9-12-7-11 4-16 12-16 20 4 0 6 0 10-2z"/>
-        </g>
-        <path fill="#E79A3A" d="M76 196c-6 0-12 6-12 12v8h128v-8c0-6-6-12-12-12H76z"/>
+      <ellipse cx="128" cy="210" rx="52" ry="14" fill="#000" opacity=".06"/>
+      <g fill="#E79A3A">
+        <path d="M64 82c6-14 28-22 46-18 7 2 12 7 14 13 2-6 7-11 14-13 18-4 40 4 46 18 3 7 0 14-8 18-12 6-28 3-40-7-3-3-5-6-6-9-1 3-3 6-6 9-12 10-28 13-40 7-8-4-11-11-8-18z"/>
+        <path d="M64 118c0-28 27-50 64-50s64 22 64 50-27 66-64 66-64-38-64-66z"/>
+        <path d="M92 178c0-7 16-10 36-10s36 3 36 10v12H92v-12z" fill="#D5832E"/>
       </g>
+      {/* eyes + nose + mouth */}
+      <g fill="#111">
+        <circle cx="108" cy={eyes.cy} r={eyes.r}/><circle cx="148" cy={eyes.cy} r={eyes.r}/>
+        {variant === 'thinking'
+          ? <rect x="112" y="136" width="32" height="4" rx="2"/>
+          : <path d="M112 140c8 8 24 8 32 0 4-4 9 2 6 6-12 12-32 12-44 0-3-4 2-10 6-6z"/>}
+        <circle cx="128" cy="130" r="4" fill="#8B3A20"/>
+      </g>
+
+      {/* accessories */}
+      {variant === 'medal' && (
+        <>
+          <circle cx="128" cy="168" r="18" fill="#F6C32C" stroke="#D4A81F" />
+          <text x="128" y="174" textAnchor="middle" fontSize="14" fontWeight="700" fill="#8B3A20">1</text>
+          <path d="M120 150l-12-10h40l-12 10" fill="#C0392B" opacity=".8"/>
+        </>
+      )}
+      {variant === 'tablet' && <rect x="100" y="150" width="56" height="42" rx="6" fill="#2B2B2B" />}
+      {variant === 'book' && (
+        <g>
+          <path d="M96 148h64v30a6 6 0 0 1-6 6H102a6 6 0 0 1-6-6v-30z" fill="#E35D2A"/>
+          <path d="M128 148v36" stroke="#fff" strokeWidth="2"/>
+        </g>
+      )}
     </svg>
   );
 }

--- a/components/CameraCapture.tsx
+++ b/components/CameraCapture.tsx
@@ -70,7 +70,7 @@ export default function CameraCapture({
         <video ref={videoRef} playsInline muted className="w-full h-auto bg-black"/>
       </div>
       <canvas ref={canvasRef} className="hidden"/>
-      <button className="btn-primary w-full h-14 rounded-2xl" onClick={snapAndAnalyze} disabled={loading}>
+      <button className="btn-hero w-full" onClick={snapAndAnalyze} disabled={loading}>
         {loading ? 'Analisi…' : ctaLabel}
       </button>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,17 @@ import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: [
+          'SF Pro Display','SF Pro Text','-apple-system','system-ui','Inter','ui-sans-serif','sans-serif'
+        ],
+      },
+      colors: { brand: { DEFAULT: '#176d46' } },
+      borderRadius: { '2xl': '1.25rem' },
+    },
+  },
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
## Summary
- refine typography and button styles, add brand color and rounded corners
- implement Buddy variants and redesign pages: home, quiz flow, summary, progress, account, paywall
- update bottom navigation and camera capture button styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f793538e88332a624cd6c72fd726d