### PR TITLE
Add static Tailwind stylesheet to document head

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,0 +1,9 @@
+export default function Head() {
+  return (
+    <>
+      <link rel="stylesheet" href="/tw.css" />
+      <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+      <title>Buddy — Quiz AI</title>
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,8 @@
 import './globals.css';
-import type { Metadata } from 'next';
-
-export const metadata: Metadata = {
-  title: 'Buddy — Quiz AI',
-  viewport: { width: 'device-width', initialScale: 1, viewportFit: 'cover' },
-};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="it">
-      <head>
-        {/* CSS statico generato da Tailwind in prebuild */}
-        <link rel="stylesheet" href="/tw.css" />
-      </head>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Summary
- load precompiled `/tw.css` via new `app/head.tsx`
- simplify root layout to rely on head injection while keeping `globals.css` for dev

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test` *(fails: Missing script: "test")*
- `curl -s https://web-app-quiz-ai.vercel.app | grep -o '/tw.css' -m1`

------
https://chatgpt.com/codex/tasks/task_e_689f8f3884c48332a1e7a17ee1f0a713