### PR TITLE
Fix quiz start gating and state

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -1,21 +1,24 @@
 'use client';
+
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Buddy from '@/components/Buddy';
+import BuddyHero from '@/components/BuddyHero';
 import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
 import { useSessionStore } from '@/store/useSessionStore';
-import { useUserStore } from '@/store/useUserStore';
+// ⚠️ niente check quote qui: il gating avviene in /quiz dentro CameraCapture
 
 export default function HomePage() {
   const router = useRouter();
-  const startSession = useSessionStore(s => s.startSession);
-  const canUseQuiz = useUserStore(s => s.canUseQuiz);
+  const startSession = useSessionStore((s) => s.startSession);
+
   const [sel, setSel] = useState<PickerChange>({ course: '', subject: '' });
+  const ready = sel.course !== '' && sel.subject !== '';
 
   const start = () => {
-    const ok = canUseQuiz();
-    if (!ok.allowed) { alert(ok.reason || 'Limite raggiunto'); return; }
-    if (!sel.course || !sel.subject) return;
+    if (!ready) {
+      alert('Seleziona Corso di Laurea e Materia');
+      return;
+    }
     startSession(sel.course, sel.subject);
     router.push('/quiz');
   };
@@ -26,15 +29,24 @@ export default function HomePage() {
         <h1 className="h1">Allenati con<br/>Buddy</h1>
       </header>
 
-      <Buddy className="w-48 h-48 mx-auto" />
+      <div className="w-full flex justify-center">
+        <BuddyHero className="w-48 h-auto" />
+      </div>
 
       <p className="sub text-center">Puoi provare gratis un quiz completo</p>
 
       <div className="card p-4">
-        <CourseSubjectPicker onChange={setSel} />
+        <CourseSubjectPicker value={sel} onChange={setSel} />
       </div>
 
-      <button onClick={start} className="btn-hero w-full">Inizia subito</button>
+      <button
+        onClick={start}
+        disabled={!ready}
+        className="btn-hero w-full disabled:opacity-50 disabled:pointer-events-none"
+      >
+        Inizia subito
+      </button>
+
       <div className="h-20" />
     </div>
   );

--- a/components/CourseSubjectPicker.tsx
+++ b/components/CourseSubjectPicker.tsx
@@ -1,37 +1,48 @@
 'use client';
+
 export type PickerChange = { course: string; subject: string };
 
-const courses = ['Informatica', 'Ingegneria', 'Economia'];
-const subjects = ['Algoritmi', 'Reti', 'Diritto', 'Statistica'];
+const COURSES = ['Informatica', 'Ingegneria', 'Economia'];
+const SUBJECTS = ['Algoritmi', 'Reti', 'Diritto', 'Statistica'];
 
 export default function CourseSubjectPicker({
-  defaultCourse = '', defaultSubject = '', onChange,
-}: { defaultCourse?: string; defaultSubject?: string; onChange?: (v: PickerChange) => void; }) {
-  const emit = (c: string, s: string) => onChange?.({ course: c, subject: s });
+  value,
+  onChange,
+  courses = COURSES,
+  subjects = SUBJECTS,
+}: {
+  value: PickerChange;                       // ← controlled
+  onChange: (v: PickerChange) => void;       // ← controlled
+  courses?: string[];
+  subjects?: string[];
+}) {
   return (
     <div className="grid gap-3">
       <label className="block">
         <span className="text-sm text-neutral-600">Corso di Laurea</span>
         <select
-          id="course"
-          defaultValue={defaultCourse}
-          onChange={(e) => emit(e.target.value, (document.getElementById('subject') as HTMLSelectElement)?.value || '')}
+          value={value.course}
+          onChange={(e) => onChange({ course: e.target.value, subject: value.subject })}
           className="mt-1 w-full h-12 rounded-2xl border border-neutral-200 bg-white px-3"
         >
-          <option value="" disabled>Seleziona corso</option>
-          {courses.map(c => <option key={c} value={c}>{c}</option>)}
+          <option value="">Seleziona corso</option>
+          {courses.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
         </select>
       </label>
+
       <label className="block">
         <span className="text-sm text-neutral-600">Materia</span>
         <select
-          id="subject"
-          defaultValue={defaultSubject}
-          onChange={(e) => emit((document.getElementById('course') as HTMLSelectElement)?.value || '', e.target.value)}
+          value={value.subject}
+          onChange={(e) => onChange({ course: value.course, subject: e.target.value })}
           className="mt-1 w-full h-12 rounded-2xl border border-neutral-200 bg-white px-3"
         >
-          <option value="" disabled>Seleziona materia</option>
-          {subjects.map(s => <option key={s} value={s}>{s}</option>)}
+          <option value="">Seleziona materia</option>
+          {subjects.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
         </select>
       </label>
     </div>


### PR DESCRIPTION
## Summary
- Convert `CourseSubjectPicker` to a controlled component with default course and subject lists
- Allow quiz sessions to start once course and subject are selected and remove user quota gating from home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f9cc29f688332ba3fcd5af0ea486a