### PR TITLE
feat: enable flexible CTA and dynamic APIs

### DIFF
--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -1,3 +1,7 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'edge'; // opzionale ma consigliato: supabase-js v2 supporta edge
+
 import { getSupabaseClient } from '@/lib/supabase';
 
 export async function GET() {
@@ -11,3 +15,4 @@ export async function GET() {
     headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0' }
   });
 }
+

--- a/app/api/subjects/route.ts
+++ b/app/api/subjects/route.ts
@@ -1,3 +1,7 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const runtime = 'edge'; // opzionale ma consigliato: supabase-js v2 supporta edge
+
 import { getSupabaseClient } from '@/lib/supabase';
 
 export async function GET(req: Request) {
@@ -16,3 +20,4 @@ export async function GET(req: Request) {
     headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0' }
   });
 }
+

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,7 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
 export function getSupabaseClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    // Non alzare errore in fase di build: fallisci a runtime con messaggio chiaro
+    throw new Error('Supabase non configurato: aggiungi NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.');
+  }
   return createClient(url, key, { auth: { persistSession: false } });
 }
+


### PR DESCRIPTION
## Summary
- Enable CTA once course or subject IDs/names are present and start sessions with valid strings
- Force dynamic rendering for courses and subjects API routes to fix Vercel builds
- Add clear runtime error when Supabase environment variables are missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a102ef08fc8332badb6f4d458647ab