### PR TITLE
Fix Supabase picker + CTA

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -6,31 +6,24 @@ import BuddyHero from '@/components/BuddyHero';
 import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
 import { useSessionStore } from '@/store/useSessionStore';
 
-// compat: accettiamo sia lo schema nuovo (courseId/subjectId) sia quello vecchio (course/subject)
 type AnySel = PickerChange & { course?: string; subject?: string };
 
 function isReady(sel: AnySel) {
-  const courseOk  = Boolean(sel.courseId || sel.course);
-  const subjectOk = Boolean(sel.subjectId || sel.subject);
-  return courseOk && subjectOk;
+  return Boolean(sel.courseId || sel.course) && Boolean(sel.subjectId || sel.subject);
 }
-
 function getNames(sel: AnySel) {
-  const courseName  = sel.courseName || sel.course || sel.courseId || '';
-  const subjectName = sel.subjectName || sel.subject || sel.subjectId || '';
-  return { courseName, subjectName };
+  return {
+    courseName: sel.courseName || sel.course || sel.courseId || '',
+    subjectName: sel.subjectName || sel.subject || sel.subjectId || '',
+  };
 }
 
 export default function HomePage() {
   const router = useRouter();
   const startSession = useSessionStore(s => s.startSession);
-
-  const [sel, setSel] = useState<AnySel>({
-    courseId: '', courseName: '', subjectId: '', subjectName: ''
-  });
+  const [sel, setSel] = useState<AnySel>({ courseId: '', courseName: '', subjectId: '', subjectName: '' });
 
   const ready = isReady(sel);
-
   const go = () => {
     if (!ready) return;
     const { courseName, subjectName } = getNames(sel);
@@ -52,7 +45,7 @@ export default function HomePage() {
         <p className="sub text-center">Puoi provare gratis un quiz completo</p>
 
         <div className="card p-4">
-          <CourseSubjectPicker value={sel as PickerChange} onChange={(v) => setSel(v)} />
+          <CourseSubjectPicker value={sel as PickerChange} onChange={setSel} />
         </div>
 
         <button
@@ -69,4 +62,3 @@ export default function HomePage() {
     </main>
   );
 }
-

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -1,18 +1,21 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const runtime = 'edge'; // opzionale ma consigliato: supabase-js v2 supporta edge
+export const runtime = 'nodejs';
 
 import { getSupabaseClient } from '@/lib/supabase';
 
 export async function GET() {
-  const supabase = getSupabaseClient();
-  const { data, error } = await supabase
-    .from('courses')
-    .select('id,name')
-    .order('name', { ascending: true });
-  if (error) return new Response(JSON.stringify({ error: error.message }), { status: 400 });
-  return new Response(JSON.stringify(data), {
-    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0' }
-  });
+  try {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id,name')
+      .order('name', { ascending: true });
+    if (error) throw error;
+    return new Response(JSON.stringify(data ?? []), {
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  } catch (e: any) {
+    return new Response(JSON.stringify({ error: String(e?.message || e) }), { status: 400 });
+  }
 }
-

--- a/app/api/subjects/route.ts
+++ b/app/api/subjects/route.ts
@@ -1,23 +1,58 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
-export const runtime = 'edge'; // opzionale ma consigliato: supabase-js v2 supporta edge
+export const runtime = 'nodejs';
 
 import { getSupabaseClient } from '@/lib/supabase';
 
-export async function GET(req: Request) {
-  const url = new URL(req.url);
-  const courseId = url.searchParams.get('courseId');
-  if (!courseId) return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
-
-  const supabase = getSupabaseClient();
-  const { data, error } = await supabase
-    .from('subjects')
-    .select('id,name')
-    .eq('course_id', courseId)
-    .order('name', { ascending: true });
-  if (error) return new Response(JSON.stringify({ error: error.message }), { status: 400 });
-  return new Response(JSON.stringify(data), {
-    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0' }
-  });
+function extractCourseId(raw: string | null) {
+  if (!raw) return null;
+  const dec = decodeURIComponent(raw);
+  // UUID classico?
+  if (/^[0-9a-fA-F-]{36}$/.test(dec)) return dec;
+  // In caso arrivasse JSON, prendi .id
+  try {
+    const obj = JSON.parse(dec);
+    if (Array.isArray(obj) && obj[0]?.id) return String(obj[0].id);
+    if (obj && typeof obj === 'object' && 'id' in obj) return String((obj as any).id);
+  } catch {}
+  return null;
 }
 
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    let courseId = extractCourseId(url.searchParams.get('courseId'));
+    const courseName = url.searchParams.get('courseName');
+
+    const supabase = getSupabaseClient();
+
+    // Fallback: se non c'è l'UUID ma abbiamo il nome, risolvi l'ID
+    if (!courseId && courseName) {
+      const { data: row, error: cErr } = await supabase
+        .from('courses')
+        .select('id')
+        .eq('name', courseName)
+        .maybeSingle();
+      if (cErr) throw cErr;
+      courseId = row?.id || null;
+    }
+
+    if (!courseId) {
+      return new Response(JSON.stringify([]), { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const { data, error } = await supabase
+      .from('subjects')
+      .select('id,name')
+      .eq('course_id', courseId)
+      .order('name', { ascending: true });
+
+    if (error) throw error;
+
+    return new Response(JSON.stringify(data ?? []), {
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  } catch (e: any) {
+    return new Response(JSON.stringify({ error: String(e?.message || e) }), { status: 400 });
+  }
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -4,9 +4,7 @@ export function getSupabaseClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) {
-    // Non alzare errore in fase di build: fallisci a runtime con messaggio chiaro
-    throw new Error('Supabase non configurato: aggiungi NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY.');
+    throw new Error('Supabase non configurato: NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY mancanti.');
   }
   return createClient(url, key, { auth: { persistSession: false } });
 }
-


### PR DESCRIPTION
## Summary
- load courses and subjects from Supabase with runtime sanitization
- normalize picker IDs and enable CTA navigation
- ensure home page starts quiz with selected course and subject

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(terminated early after build trace collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a119ff0b288332a60c9fc10113104b