### PR TITLE
feat: resilient picker with debug banner

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -5,64 +5,36 @@ import { useRouter } from 'next/navigation';
 import BuddyHero from '@/components/BuddyHero';
 import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
 import { useSessionStore } from '@/store/useSessionStore';
+import DebugBanner from '@/components/DebugBanner';
 
-// compat: accetta anche eventuali vecchi campi (course/subject)
 type AnySel = PickerChange & { course?: string; subject?: string };
-
-function isReady(sel: AnySel) {
-  return Boolean(sel.courseId || sel.course) && Boolean(sel.subjectId || sel.subject);
-}
-function getNames(sel: AnySel) {
-  return {
-    courseName: sel.courseName || sel.course || sel.courseId || '',
-    subjectName: sel.subjectName || sel.subject || sel.subjectId || '',
-  };
-}
+const isReady = (s: AnySel) => Boolean(s.courseId || s.course) && Boolean(s.subjectId || s.subject);
+const getNames = (s: AnySel) => ({ courseName: s.courseName || s.course || s.courseId || '', subjectName: s.subjectName || s.subject || s.subjectId || '' });
 
 export default function HomePage() {
   const router = useRouter();
   const startSession = useSessionStore(s => s.startSession);
-  const [sel, setSel] = useState<AnySel>({
-    courseId: '', courseName: '', subjectId: '', subjectName: ''
-  });
-
-  const ready = isReady(sel);
+  const [sel, setSel] = useState<AnySel>({ courseId: '', courseName: '', subjectId: '', subjectName: '' });
+  const [lastError, setLastError] = useState<string|null>(null);
 
   const go = () => {
-    if (!ready) return;
+    if (!isReady(sel)) return;
     const { courseName, subjectName } = getNames(sel);
     startSession(courseName, subjectName);
     router.push('/quiz');
   };
 
   return (
-    <main className="flex-1 p-4 pb-32">
-      <div className="space-y-6">
-        <header className="text-center mt-6">
-          <h1 className="h1">Allenati con<br/>Buddy</h1>
-        </header>
-
-        <div className="w-full flex justify-center">
-          <BuddyHero className="w-48 h-auto" />
-        </div>
-
-        <p className="sub text-center">Puoi provare gratis un quiz completo</p>
-
-        <div className="card p-4">
-          <CourseSubjectPicker value={sel as PickerChange} onChange={setSel} />
-        </div>
-
-        <button
-          type="button"
-          onClick={go}
-          disabled={!ready}
-          className="btn-hero w-full disabled:opacity-50 disabled:pointer-events-none"
-        >
-          Inizia subito
-        </button>
-
-        <div className="h-20" />
+    <main className="flex-1 p-4 pb-32 space-y-6">
+      <header className="text-center mt-6"><h1 className="h1">Allenati con<br/>Buddy</h1></header>
+      <div className="w-full flex justify-center"><BuddyHero className="w-48 h-auto" /></div>
+      <p className="sub text-center">Puoi provare gratis un quiz completo</p>
+      <div className="card p-4">
+        <CourseSubjectPicker value={sel as PickerChange} onChange={setSel} onError={setLastError} />
       </div>
+      <button type="button" onClick={go} disabled={!isReady(sel)} className="btn-hero w-full disabled:opacity-50 disabled:pointer-events-none">Inizia subito</button>
+      <div className="h-20" />
+      <DebugBanner lastError={lastError} />
     </main>
   );
 }

--- a/components/DebugBanner.tsx
+++ b/components/DebugBanner.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Health = {
+  ok: boolean;
+  env: { hasUrl: boolean; hasKey: boolean };
+  counts: { courses: number; subjects: number };
+  errors?: { courses?: string|null; subjects?: string|null };
+  error?: string;
+};
+
+export default function DebugBanner({ lastError }: { lastError?: string|null }) {
+  const [h, setH] = useState<Health | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const show = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('debug') === '1';
+    setVisible(show);
+    if (!show) return;
+    fetch('/api/health', { cache: 'no-store' })
+      .then(r => r.json())
+      .then(setH)
+      .catch(e => setH({ ok:false, env:{hasUrl:false,hasKey:false}, counts:{courses:0,subjects:0}, error:String(e) }));
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-16 left-2 right-2 z-[9999] rounded-xl border bg-white shadow p-3 text-[11px]">
+      <div className="font-semibold mb-1">DEBUG</div>
+      <pre className="whitespace-pre-wrap break-words">
+        {JSON.stringify(h, null, 2)}
+      </pre>
+      {lastError && <div className="mt-2 text-red-600">pickerError: {lastError}</div>}
+    </div>
+  );
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,20 +1,24 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
+// Next.js inietta queste stringhe a build-time nel client (inlined)
+const PUBLIC_URL = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
+const PUBLIC_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string | undefined;
+
 function required<T>(v: T | undefined, name: string): T {
   if (!v) throw new Error(`${name} is missing`);
   return v;
 }
 
 export function getSupabaseClient(): SupabaseClient {
-  const url = required(process.env.NEXT_PUBLIC_SUPABASE_URL, 'NEXT_PUBLIC_SUPABASE_URL');
-  const key = required(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY, 'NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  // lato server (route handlers) usiamo le NEXT_PUBLIC, sono ok per SELECT con RLS
+  const url = required(PUBLIC_URL, 'NEXT_PUBLIC_SUPABASE_URL');
+  const key = required(PUBLIC_KEY, 'NEXT_PUBLIC_SUPABASE_ANON_KEY');
   return createClient(url, key, { auth: { persistSession: false } });
 }
 
-// Per il fallback client-side
+// fallback lato browser: usa le stesse NEXT_PUBLIC (inlined)
 export function getBrowserSupabase(): SupabaseClient {
-  const url = (process as any).env?.NEXT_PUBLIC_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = (process as any).env?.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !key) throw new Error('Supabase env not available in browser');
+  const url = required(PUBLIC_URL, 'NEXT_PUBLIC_SUPABASE_URL');
+  const key = required(PUBLIC_KEY, 'NEXT_PUBLIC_SUPABASE_ANON_KEY');
   return createClient(url, key, { auth: { persistSession: false } });
 }


### PR DESCRIPTION
## Summary
- simplify Supabase client to use inlined NEXT_PUBLIC values and expose browser fallback
- add DebugBanner component that fetches `/api/health` when `?debug=1` and shows picker errors
- make course/subject picker resilient with API-first then Supabase fallback and error reporting
- integrate DebugBanner into the home tab while keeping "Inizia subito" CTA

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a19cb3ffb48332a9065991080d1fbc