### PR TITLE
fix: server-side courses and dynamic subject picker

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -1,40 +1,31 @@
-'use client';
-
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import BuddyHero from '@/components/BuddyHero';
-import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
-import { useSessionStore } from '@/store/useSessionStore';
-import DebugBanner from '@/components/DebugBanner';
+import CourseSubjectPickerClient from '@/components/CourseSubjectPicker';
+import { getSupabaseClient } from '@/lib/supabase';
 
-type AnySel = PickerChange & { course?: string; subject?: string };
-const isReady = (s: AnySel) => Boolean(s.courseId || s.course) && Boolean(s.subjectId || s.subject);
-const getNames = (s: AnySel) => ({ courseName: s.courseName || s.course || s.courseId || '', subjectName: s.subjectName || s.subject || s.subjectId || '' });
-
-export default function HomePage() {
-  const router = useRouter();
-  const startSession = useSessionStore(s => s.startSession);
-  const [sel, setSel] = useState<AnySel>({ courseId: '', courseName: '', subjectId: '', subjectName: '' });
-  const [lastError, setLastError] = useState<string|null>(null);
-
-  const go = () => {
-    if (!isReady(sel)) return;
-    const { courseName, subjectName } = getNames(sel);
-    startSession(courseName, subjectName);
-    router.push('/quiz');
-  };
+export default async function HomePage() {
+  const supabase = getSupabaseClient();
+  const { data: initialCourses = [] } = await supabase
+    .from('courses')
+    .select('id,name')
+    .order('name', { ascending: true });
 
   return (
     <main className="flex-1 p-4 pb-32 space-y-6">
-      <header className="text-center mt-6"><h1 className="h1">Allenati con<br/>Buddy</h1></header>
-      <div className="w-full flex justify-center"><BuddyHero className="w-48 h-auto" /></div>
-      <p className="sub text-center">Puoi provare gratis un quiz completo</p>
-      <div className="card p-4">
-        <CourseSubjectPicker value={sel as PickerChange} onChange={setSel} onError={setLastError} />
+      <header className="text-center mt-6">
+        <h1 className="h1">Allenati con<br/>Buddy</h1>
+      </header>
+
+      <div className="w-full flex justify-center">
+        <BuddyHero className="w-48 h-auto" />
       </div>
-      <button type="button" onClick={go} disabled={!isReady(sel)} className="btn-hero w-full disabled:opacity-50 disabled:pointer-events-none">Inizia subito</button>
+
+      <p className="sub text-center">Puoi provare gratis un quiz completo</p>
+
+      <div className="card p-4">
+        <CourseSubjectPickerClient initialCourses={initialCourses} />
+      </div>
+
       <div className="h-20" />
-      <DebugBanner lastError={lastError} />
     </main>
   );
 }

--- a/app/api/subjects/route.ts
+++ b/app/api/subjects/route.ts
@@ -25,8 +25,9 @@ export async function GET(req: Request) {
     const supabase = getSupabaseClient();
 
     if (!courseId && courseName) {
-      const { data: row, error: e2 } = await supabase.from('courses').select('id').eq('name', courseName).maybeSingle();
-      if (e2) throw e2;
+      const { data: row, error } = await supabase
+        .from('courses').select('id').eq('name', courseName).maybeSingle();
+      if (error) throw error;
       courseId = row?.id || null;
     }
 

--- a/components/CourseSubjectPicker.tsx
+++ b/components/CourseSubjectPicker.tsx
@@ -1,12 +1,10 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { getBrowserSupabase } from '@/lib/supabase';
+import { useRouter } from 'next/navigation';
 import { fetchWithTimeout } from '@/lib/fetchWithTimeout';
+import { getBrowserSupabase } from '@/lib/supabase';
+import { useSessionStore } from '@/store/useSessionStore';
 
-export type PickerChange = {
-  courseId: string;  courseName: string;
-  subjectId: string; subjectName: string;
-};
 type Option = { id: string; name: string };
 
 function normalizeId(v: string) {
@@ -20,83 +18,82 @@ function normalizeId(v: string) {
   return v;
 }
 
-export default function CourseSubjectPicker({
-  value, onChange, onError,
-}: {
-  value: PickerChange;
-  onChange: (v: PickerChange) => void;
-  onError?: (msg: string|null) => void;
-}) {
-  const [courses, setCourses] = useState<Option[]>([]);
+export default function CourseSubjectPickerClient({
+  initialCourses,
+}: { initialCourses: Option[] }) {
+  const router = useRouter();
+  const startSession = useSessionStore(s => s.startSession);
+
+  const [courses, setCourses] = useState<Option[]>(initialCourses || []);
   const [subjects, setSubjects] = useState<Option[]>([]);
-  const [loadingCourses, setLoadingCourses] = useState(true);
+  const [courseId, setCourseId] = useState<string>('');
+  const [courseName, setCourseName] = useState<string>('');
+  const [subjectId, setSubjectId] = useState<string>('');
+  const [subjectName, setSubjectName] = useState<string>('');
+
+  const [loadingCourses, setLoadingCourses] = useState(!initialCourses?.length);
   const [loadingSubjects, setLoadingSubjects] = useState(false);
-  const [apiError, setApiError] = useState<string | null>(null);
+  const ready = Boolean(courseId && subjectId);
 
-  const setErr = (msg: string|null) => { setApiError(msg); onError?.(msg); };
+  // In caso l’SSR fosse vuoto, prova a caricare anche lato client
+  useEffect(() => {
+    if (initialCourses?.length) return;
+    (async () => {
+      setLoadingCourses(true);
+      try {
+        const r = await fetchWithTimeout('/api/courses', { cache: 'no-store' }, 6000);
+        const j = await r.json().catch(() => []);
+        if (Array.isArray(j) && j.length) { setCourses(j); return; }
+        // fallback diretto Supabase
+        const sb = getBrowserSupabase();
+        const { data } = await sb.from('courses').select('id,name').order('name', { ascending: true });
+        setCourses(data ?? []);
+      } finally {
+        setLoadingCourses(false);
+      }
+    })();
+  }, [initialCourses]);
 
-  async function loadCourses() {
-    setLoadingCourses(true);
-    setErr(null);
-    try {
-      // 1) API con timeout
-      const r = await fetchWithTimeout('/api/courses', { cache: 'no-store' }, 6000);
-      const j = await r.json().catch(() => []);
-      if (Array.isArray(j) && j.length) { setCourses(j); return; }
+  // Materie ogni volta che cambia corso
+  useEffect(() => {
+    if (!courseId) { setSubjects([]); setSubjectId(''); setSubjectName(''); return; }
+    (async () => {
+      setLoadingSubjects(true);
+      try {
+        const r = await fetchWithTimeout(`/api/subjects?courseId=${encodeURIComponent(courseId)}`, { cache: 'no-store' }, 6000);
+        const j = await r.json().catch(() => []);
+        if (Array.isArray(j) && j.length) { setSubjects(j); return; }
+        // fallback
+        const sb = getBrowserSupabase();
+        const { data } = await sb
+          .from('subjects').select('id,name').eq('course_id', courseId).order('name', { ascending: true });
+        setSubjects(data ?? []);
+      } finally {
+        setLoadingSubjects(false);
+      }
+    })();
+  }, [courseId]);
 
-      // 2) Fallback client → Supabase (richiede CSP connect-src)
-      const sb = getBrowserSupabase();
-      const { data, error } = await sb.from('courses').select('id,name').order('name', { ascending: true });
-      if (error) throw error;
-      setCourses(data ?? []);
-      if (!data?.length) setErr('Nessun corso disponibile.');
-    } catch (e: any) {
-      setErr(e?.message || 'Impossibile caricare i corsi.');
-      setCourses([]);
-    } finally {
-      setLoadingCourses(false);
-    }
+  function go() {
+    if (!ready) return;
+    startSession(courseName || courseId, subjectName || subjectId);
+    router.push('/quiz');
   }
-
-  async function loadSubjects(courseId: string) {
-    if (!courseId) { setSubjects([]); return; }
-    setLoadingSubjects(true);
-    setErr(null);
-    try {
-      const r = await fetchWithTimeout(`/api/subjects?courseId=${encodeURIComponent(courseId)}`, { cache: 'no-store' }, 6000);
-      const j = await r.json().catch(() => []);
-      if (Array.isArray(j) && j.length) { setSubjects(j); return; }
-
-      const sb = getBrowserSupabase();
-      const { data, error } = await sb
-        .from('subjects')
-        .select('id,name')
-        .eq('course_id', courseId)
-        .order('name', { ascending: true });
-      if (error) throw error;
-      setSubjects(data ?? []);
-      if (!data?.length) setErr('Nessuna materia per il corso selezionato.');
-    } catch (e: any) {
-      setErr(e?.message || 'Impossibile caricare le materie.');
-      setSubjects([]);
-    } finally {
-      setLoadingSubjects(false);
-    }
-  }
-
-  useEffect(() => { loadCourses(); }, []);
-  useEffect(() => { loadSubjects(value.courseId); }, [value.courseId]);
 
   return (
     <div className="grid gap-3">
+      {/* Corso */}
       <label className="block">
         <span className="text-sm text-neutral-600">Corso di Laurea</span>
         <select
-          value={value.courseId}
+          value={courseId}
           onChange={(e) => {
             const id = normalizeId(e.target.value);
             const name = courses.find(c => c.id === id)?.name || '';
-            onChange({ courseId: id, courseName: name, subjectId: '', subjectName: '' });
+            setCourseId(id);
+            setCourseName(name);
+            setSubjectId('');
+            setSubjectName('');
           }}
           className="mt-1 w-full h-12 rounded-2xl border border-neutral-200 bg-white px-3"
         >
@@ -105,15 +102,17 @@ export default function CourseSubjectPicker({
         </select>
       </label>
 
+      {/* Materia */}
       <label className="block">
         <span className="text-sm text-neutral-600">Materia</span>
         <select
-          value={value.subjectId}
-          disabled={!value.courseId || loadingSubjects}
+          value={subjectId}
+          disabled={!courseId || loadingSubjects}
           onChange={(e) => {
             const id = normalizeId(e.target.value);
             const name = subjects.find(s => s.id === id)?.name || '';
-            onChange({ ...value, subjectId: id, subjectName: name });
+            setSubjectId(id);
+            setSubjectName(name);
           }}
           className="mt-1 w-full h-12 rounded-2xl border border-neutral-200 bg-white px-3 disabled:bg-neutral-100"
         >
@@ -122,13 +121,15 @@ export default function CourseSubjectPicker({
         </select>
       </label>
 
-      {apiError && (
-        <div className="text-xs text-red-600">
-          {apiError}{' '}
-          <button type="button" onClick={loadCourses} className="underline">Riprova</button>
-          {' · '}<a className="underline" href="/api/health" target="_blank" rel="noreferrer">/api/health</a>
-        </div>
-      )}
+      {/* CTA */}
+      <button
+        type="button"
+        onClick={go}
+        disabled={!ready}
+        className="btn-hero w-full disabled:opacity-50 disabled:pointer-events-none"
+      >
+        Inizia subito
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- load courses server-side and pass to client
- fetch subjects through API with Supabase fallback
- start quiz session from picker CTA

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a1c036b7d88332838ee728c5a79a34