### PR TITLE
Subjects seed + RLS: Materie selezionabili per ogni corso

### DIFF
--- a/docs/SUPABASE_SETUP.md
+++ b/docs/SUPABASE_SETUP.md
@@ -1,0 +1,55 @@
+# Supabase – Seed & RLS per Materie (Subjects)
+
+## 1) Esegui il seed delle materie
+- Vai su **Supabase → SQL Editor**
+- Incolla il contenuto di `supabase/seed/seed_subjects.sql`
+- Clicca **Run**
+
+## 2) Abilita RLS/Policy su `subjects`
+- Sempre nel SQL Editor, incolla `supabase/policies/subjects_read.sql`
+- **Run**
+
+## 3) Verifica dati presenti
+```sql
+select c.name, count(s.id) as subjects_count
+from public.courses c
+left join public.subjects s on s.course_id = c.id
+group by c.id, c.name
+order by c.name;
+```
+Devi vedere subjects_count > 0 per ogni corso.
+
+---
+
+### 2) (Facoltativo ma utile) Health API unica
+
+Se **non esiste già**, crea `app/api/health/route.ts` per un controllo rapido:
+
+```ts
+// app/api/health/route.ts
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function GET() {
+  try {
+    const sb = getSupabaseClient();
+
+    const { count: coursesCount } = await sb.from('courses').select('id', { count: 'exact', head: true });
+    const { count: subjectsCount } = await sb.from('subjects').select('id', { count: 'exact', head: true });
+
+    return new Response(JSON.stringify({
+      ok: true,
+      env: {
+        hasUrl: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
+        hasKey: !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      },
+      counts: { courses: coursesCount ?? 0, subjects: subjectsCount ?? 0 },
+    }), { headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }});
+  } catch (e: any) {
+    return new Response(JSON.stringify({ ok: false, error: String(e?.message || e) }), { status: 500 });
+  }
+}
+```
+

--- a/supabase/policies/subjects_read.sql
+++ b/supabase/policies/subjects_read.sql
@@ -1,0 +1,11 @@
+-- Abilita RLS e consenti SELECT a anon+authenticated su subjects
+alter table public.subjects enable row level security;
+
+drop policy if exists "read subjects" on public.subjects;
+
+create policy "read subjects"
+on public.subjects
+for select
+to anon, authenticated
+using (true);
+

--- a/supabase/seed/seed_subjects.sql
+++ b/supabase/seed/seed_subjects.sql
@@ -1,0 +1,25 @@
+-- Seed materie per i corsi esistenti (idempotente)
+with
+  econ as (select id from public.courses where name = 'Economia' limit 1),
+  info as (select id from public.courses where name = 'Informatica' limit 1),
+  ing  as (select id from public.courses where name = 'Ingegneria' limit 1),
+  nut  as (select id from public.courses where name = 'Scienze della Nutrizione' limit 1)
+insert into public.subjects (course_id, name, slug)
+select econ.id, 'Microeconomia', 'microeconomia' from econ
+union all select econ.id, 'Macroeconomia', 'macroeconomia' from econ
+
+union all select info.id, 'Algoritmi',    'algoritmi'     from info
+union all select info.id, 'Basi di Dati', 'basi-di-dati'  from info
+
+union all select ing.id,  'Analisi 1',    'analisi-1'     from ing
+union all select ing.id,  'Fisica 1',     'fisica-1'      from ing
+
+union all select nut.id,  'Biochimica',   'biochimica'    from nut
+union all select nut.id,  'Fisiologia',   'fisiologia'    from nut
+on conflict (course_id, name) do nothing;
+
+-- Verifica rapida (facoltativa)
+-- select c.name, count(s.id) as subjects_count
+-- from public.courses c left join public.subjects s on s.course_id = c.id
+-- group by c.id, c.name order by c.name;
+


### PR DESCRIPTION
## Summary
- seed initial subjects for existing courses
- add read-only RLS policy for `public.subjects`
- document Supabase setup steps and optional health API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint config; lint skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a20a898aac83329d34bb94f2fd84a2