### PR TITLE
Restore Home premium UI + robust subjects picker & APIs

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -2,23 +2,53 @@
 import { useState } from 'react';
 import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
 import Button from '@/components/Button';
+import Buddy from '@/components/Buddy';
 import { useRouter } from 'next/navigation';
+import { useSessionStore } from '@/store/useSessionStore';
 
 export default function HomePage() {
   const router = useRouter();
   const [sel, setSel] = useState<PickerChange>({});
+  const startSession = useSessionStore((s) => s.startSession);
 
   const start = () => {
     if (!sel.courseId || !sel.subjectId) return;
-    router.push('/quiz'); // oppure conserva gli id nello store se ti serve
+    startSession(sel.courseId, sel.subjectId);
+    router.push('/quiz');
   };
 
   return (
-    <main className="p-4 space-y-6">
-      <CourseSubjectPicker value={sel} onChange={setSel} />
-      <Button disabled={!sel.courseId || !sel.subjectId} onClick={start}>
-        Inizia subito
-      </Button>
+    <main className="px-5 pb-28 pt-10 flex flex-col items-center">
+      {/* Titolo + Buddy */}
+      <h1 className="text-[42px] leading-tight font-black text-neutral-900 text-center">
+        Allenati con <br /> Buddy
+      </h1>
+
+      <div className="mt-6">
+        <Buddy className="w-[260px] h-[260px]" />
+      </div>
+
+      <p className="mt-6 text-[18px] text-neutral-700 text-center">
+        Puoi provare gratis un quiz completo
+      </p>
+
+      {/* Card selezioni */}
+      <section className="mt-6 w-full max-w-[680px] rounded-3xl border border-neutral-200 bg-white shadow-sm p-5">
+        <CourseSubjectPicker
+          value={sel}
+          onChange={setSel}
+        />
+
+        <div className="mt-6">
+          <Button
+            className="w-full h-14 text-[18px] rounded-2xl"
+            disabled={!sel.courseId || !sel.subjectId}
+            onClick={start}
+          >
+            Inizia subito
+          </Button>
+        </div>
+      </section>
     </main>
   );
 }

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -7,7 +7,10 @@ import { getSupabaseClient } from '@/lib/supabase';
 export async function GET() {
   try {
     const supabase = getSupabaseClient();
-    const { data, error } = await supabase.from('courses').select('id,name').order('name', { ascending: true });
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id,name,slug')
+      .order('name', { ascending: true });
     if (error) throw error;
     return new Response(JSON.stringify(data ?? []), {
       headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },

--- a/components/CourseSubjectPicker.tsx
+++ b/components/CourseSubjectPicker.tsx
@@ -1,78 +1,91 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-type Option = { id: string; name: string };
-
-export type PickerChange = {
-  courseId?: string;
-  subjectId?: string;
-};
+export type PickerChange = { courseId?: string; subjectId?: string };
+type Opt = { id: string; name: string };
 
 export default function CourseSubjectPicker({
   value,
   onChange,
 }: {
-  value?: PickerChange;
+  value: PickerChange;
   onChange: (v: PickerChange) => void;
 }) {
-  const [courses, setCourses] = useState<Option[]>([]);
-  const [subjects, setSubjects] = useState<Option[]>([]);
+  const [courses, setCourses] = useState<Opt[]>([]);
+  const [subjects, setSubjects] = useState<Opt[]>([]);
+  const [loadingCourses, setLoadingCourses] = useState(false);
   const [loadingSubjects, setLoadingSubjects] = useState(false);
 
-  // Carica corsi
+  // --- Carica corsi una volta ---
   useEffect(() => {
-    let aborted = false;
+    let off = false;
+    setLoadingCourses(true);
     fetch('/api/courses', { cache: 'no-store' })
       .then(r => r.json())
-      .then((data: Option[]) => { if (!aborted) setCourses(data); })
-      .catch(() => { if (!aborted) setCourses([]); });
-    return () => { aborted = true; };
+      .then((data: Opt[]) => { if (!off) setCourses(data ?? []); })
+      .catch(() => { if (!off) setCourses([]); })
+      .finally(() => { if (!off) setLoadingCourses(false); });
+    return () => { off = true; };
   }, []);
 
-  // Quando cambia il corso, carica le materie
+  // --- Carica materie quando cambia il corso ---
   useEffect(() => {
-    if (!value?.courseId) { setSubjects([]); onChange({ courseId: value?.courseId, subjectId: undefined }); return; }
+    if (!value?.courseId) { setSubjects([]); return; }
+    let off = false;
     setLoadingSubjects(true);
-    let aborted = false;
     fetch(`/api/subjects?courseId=${encodeURIComponent(value.courseId)}`, { cache: 'no-store' })
       .then(r => r.json())
-      .then((data: Option[]) => { if (!aborted) setSubjects(data ?? []); })
-      .catch(() => { if (!aborted) setSubjects([]); })
-      .finally(() => { if (!aborted) setLoadingSubjects(false); });
-    return () => { aborted = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      .then((data: Opt[]) => { if (!off) setSubjects(data ?? []); })
+      .catch(() => { if (!off) setSubjects([]); })
+      .finally(() => { if (!off) setLoadingSubjects(false); });
+    return () => { off = true; };
   }, [value?.courseId]);
 
+  // --- Helpers UI ---
+  const canPickSubject = !!value?.courseId && !loadingSubjects && subjects.length > 0;
+  const subjectPlaceholder = useMemo(() => {
+    if (!value?.courseId) return 'Seleziona corso prima';
+    if (loadingSubjects) return 'Carico…';
+    if (subjects.length === 0) return 'Nessuna materia disponibile';
+    return 'Seleziona materia';
+  }, [value?.courseId, loadingSubjects, subjects.length]);
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      {/* Corso */}
       <div>
-        <label className="label">Corso di Laurea</label>
+        <label className="block mb-2 text-neutral-700 text-[15px]">Corso di Laurea</label>
         <select
-          className="select"
-          value={value?.courseId ?? ''}
+          className="w-full h-14 rounded-2xl border border-neutral-200 bg-white px-4 text-[16px] focus:outline-none focus:ring-2 focus:ring-[#176d46]/25"
+          value={value.courseId ?? ''}
           onChange={(e) => onChange({ courseId: e.target.value || undefined, subjectId: undefined })}
         >
-          <option value="">{courses.length ? 'Seleziona corso' : 'Carico...'}</option>
-          {courses.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+          <option value="">
+            {loadingCourses ? 'Carico…' : (courses.length ? 'Seleziona corso' : 'Nessun corso disponibile')}
+          </option>
+          {courses.map(c => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
         </select>
       </div>
 
+      {/* Materia */}
       <div>
-        <label className="label">Materia</label>
+        <label className="block mb-2 text-neutral-700 text-[15px]">Materia</label>
         <select
-          className="select"
-          value={value?.subjectId ?? ''}
-          disabled={!value?.courseId || loadingSubjects || subjects.length === 0}
+          key={value.courseId ?? 'no-course'}           /* forza reset dell’option quando cambia corso */
+          className="w-full h-14 rounded-2xl border border-neutral-200 bg-white px-4 text-[16px] focus:outline-none focus:ring-2 focus:ring-[#176d46]/25 disabled:bg-neutral-100 disabled:text-neutral-400"
+          value={value.subjectId ?? ''}
+          disabled={!canPickSubject}
           onChange={(e) => onChange({ ...value, subjectId: e.target.value || undefined })}
         >
-          <option value="">
-            {!value?.courseId ? 'Seleziona corso prima' :
-             loadingSubjects ? 'Carico…' :
-             subjects.length ? 'Seleziona materia' : 'Nessuna materia disponibile'}
-          </option>
-          {subjects.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          <option value="">{subjectPlaceholder}</option>
+          {subjects.map(s => (
+            <option key={s.id} value={s.id}>{s.name}</option>
+          ))}
         </select>
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- expand courses API to return slug for each course
- rebuild CourseSubjectPicker with reliable course/subject loading states
- revive Home page with premium layout featuring Buddy and stable picker integration

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25efbc9608332b66bffd3b391a35c