### PR TITLE
Fix picker naming and fetch subjects by course via Supabase

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState } from 'react';
-import CourseSubjectPicker, { PickerChange } from '@/components/CourseSubjectPicker';
+import CourseSubjectPicker, { PickerValue } from '@/components/CourseSubjectPicker';
 import Button from '@/components/Button';
 import Buddy from '@/components/Buddy';
 import { useRouter } from 'next/navigation';
@@ -8,12 +8,14 @@ import { useSessionStore } from '@/store/useSessionStore';
 
 export default function HomePage() {
   const router = useRouter();
-  const [sel, setSel] = useState<PickerChange>({});
+  const [sel, setSel] = useState<PickerValue>({ course: undefined, subject: undefined });
   const startSession = useSessionStore((s) => s.startSession);
 
+  const canStart = !!sel.course && !!sel.subject;
+
   const start = () => {
-    if (!sel.courseId || !sel.subjectId) return;
-    startSession(sel.courseId, sel.subjectId);
+    if (!canStart) return;
+    startSession(sel.course!, sel.subject!);
     router.push('/quiz');
   };
 
@@ -42,7 +44,7 @@ export default function HomePage() {
         <div className="mt-6">
           <Button
             className="w-full h-14 text-[18px] rounded-2xl"
-            disabled={!sel.courseId || !sel.subjectId}
+            disabled={!canStart}
             onClick={start}
           >
             Inizia subito

--- a/components/CourseSubjectPicker.tsx
+++ b/components/CourseSubjectPicker.tsx
@@ -1,56 +1,80 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
 
-export type PickerChange = { courseId?: string; subjectId?: string };
+import { useEffect, useMemo, useState } from 'react';
+import { supaClient } from '@/lib/supabaseClient';
+
 type Opt = { id: string; name: string };
+export type PickerValue = { course?: string; subject?: string };
 
 export default function CourseSubjectPicker({
   value,
   onChange,
-}: { value: PickerChange; onChange: (v: PickerChange) => void }) {
-  const [courses, setCourses] = useState<Opt[]>([]);
+}: {
+  value: PickerValue;
+  onChange: (v: PickerValue) => void;
+}) {
+  const [courses, setCourses]   = useState<Opt[]>([]);
   const [subjects, setSubjects] = useState<Opt[]>([]);
   const [loadingC, setLoadingC] = useState(false);
   const [loadingS, setLoadingS] = useState(false);
 
+  // Carica corsi all'avvio
   useEffect(() => {
     let off = false;
-    setLoadingC(true);
-    fetch('/api/courses', { cache: 'no-store' })
-      .then(r => r.json()).then((d: Opt[]) => { if (!off) setCourses(d ?? []); })
-      .catch(() => { if (!off) setCourses([]); })
-      .finally(() => { if (!off) setLoadingC(false); });
+    (async () => {
+      setLoadingC(true);
+      const { data, error } = await supaClient
+        .from('courses')
+        .select('id,name')
+        .order('name', { ascending: true });
+      if (!off) {
+        setCourses(error ? [] : (data ?? []));
+        setLoadingC(false);
+      }
+    })();
     return () => { off = true; };
   }, []);
 
+  // Carica materie quando cambia il corso
   useEffect(() => {
-    if (!value?.courseId) { setSubjects([]); return; }
     let off = false;
-    setLoadingS(true);
-    fetch(`/api/subjects?courseId=${encodeURIComponent(value.courseId)}`, { cache: 'no-store' })
-      .then(r => r.json()).then((d: Opt[]) => { if (!off) setSubjects(d ?? []); })
-      .catch(() => { if (!off) setSubjects([]); })
-      .finally(() => { if (!off) setLoadingS(false); });
+    (async () => {
+      if (!value?.course) { setSubjects([]); return; }
+      setLoadingS(true);
+      const { data, error } = await supaClient
+        .from('subjects')
+        .select('id,name')
+        .eq('course_id', value.course)     // <-- usa l'ID del corso selezionato
+        .order('name', { ascending: true });
+      if (!off) {
+        setSubjects(error ? [] : (data ?? []));
+        setLoadingS(false);
+      }
+    })();
     return () => { off = true; };
-  }, [value?.courseId]);
+  }, [value?.course]);
+
+  const canPickSubject = !!value?.course && !loadingS && subjects.length > 0;
 
   const subjectPlaceholder = useMemo(() => {
-    if (!value?.courseId) return 'Seleziona corso prima';
-    if (loadingS) return 'Carico…';
-    if (subjects.length === 0) return 'Nessuna materia disponibile';
+    if (!value?.course)   return 'Seleziona corso prima';
+    if (loadingS)         return 'Carico…';
+    if (subjects.length===0) return 'Nessuna materia disponibile';
     return 'Seleziona materia';
-  }, [value?.courseId, loadingS, subjects.length]);
-
-  const canPickSubject = !!value?.courseId && !loadingS && subjects.length > 0;
+  }, [value?.course, loadingS, subjects.length]);
 
   return (
     <div className="space-y-6">
+      {/* Corso di Laurea — stile PR#30 invariato */}
       <div>
         <label className="block mb-2 text-neutral-700 text-[15px]">Corso di Laurea</label>
         <select
           className="w-full h-14 rounded-2xl border border-neutral-200 bg-white px-4 text-[16px] focus:outline-none focus:ring-2 focus:ring-[#176d46]/25"
-          value={value.courseId ?? ''}
-          onChange={(e) => onChange({ courseId: e.target.value || undefined, subjectId: undefined })}
+          value={value.course ?? ''}
+          onChange={(e) => {
+            const course = e.target.value || undefined;
+            onChange({ course, subject: undefined }); // reset materia al cambio corso
+          }}
         >
           <option value="">
             {loadingC ? 'Carico…' : (courses.length ? 'Seleziona corso' : 'Nessun corso disponibile')}
@@ -59,14 +83,15 @@ export default function CourseSubjectPicker({
         </select>
       </div>
 
+      {/* Materia — stile PR#30 invariato */}
       <div>
         <label className="block mb-2 text-neutral-700 text-[15px]">Materia</label>
         <select
-          key={value.courseId ?? 'no-course'}
+          key={value.course ?? 'no-course'}
           className="w-full h-14 rounded-2xl border border-neutral-200 bg-white px-4 text-[16px] focus:outline-none focus:ring-2 focus:ring-[#176d46]/25 disabled:bg-neutral-100 disabled:text-neutral-400"
           disabled={!canPickSubject}
-          value={value.subjectId ?? ''}
-          onChange={(e) => onChange({ ...value, subjectId: e.target.value || undefined })}
+          value={value.subject ?? ''}
+          onChange={(e) => onChange({ ...value, subject: e.target.value || undefined })}
         >
           <option value="">{subjectPlaceholder}</option>
           {subjects.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const URL  = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supaClient = createClient(URL, ANON, {
+  auth: { persistSession: false },
+  db: { schema: 'public' },
+});


### PR DESCRIPTION
## Summary
- add Supabase client for browser-side queries
- load courses and subjects using Supabase and align picker naming to `course`/`subject`
- update home page to use new picker value keys and enable CTA only when both selected

## Testing
- `npm i`
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a26a624978833291d7236aee150dd9