### PR TITLE
Fix overlay blocking dropdowns on landing page

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -22,22 +22,23 @@ export default function HomePage() {
   };
 
   return (
-    <main className="px-5 pb-28 pt-10 flex flex-col items-center">
+    <main className="px-5 pb-28 pt-10 flex flex-col items-center relative">
+      <div className="absolute inset-0 z-0 pointer-events-none" />
       {/* Titolo + Buddy */}
       <h1 className="text-[42px] leading-tight font-black text-neutral-900 text-center">
         Allenati con <br /> Buddy
       </h1>
 
-      <div className="mt-6">
+      <figure className="mx-auto mt-6 w-[260px] pointer-events-none select-none relative z-0">
         <Buddy className="w-[260px] h-[260px]" />
-      </div>
+      </figure>
 
       <p className="mt-6 text-[18px] text-neutral-700 text-center">
         Puoi provare gratis un quiz completo
       </p>
 
       {/* Card selezioni */}
-      <section className="mt-6 w-full max-w-[680px] rounded-3xl border border-neutral-200 bg-white shadow-sm p-5">
+      <section className="mt-10 w-full max-w-[680px] rounded-2xl border border-neutral-200 bg-white shadow-sm p-5 relative z-20 pointer-events-auto">
         <CourseSubjectPicker onChange={setSel} />
 
         <div className="mt-6">

--- a/app/_components/CourseSubjectPicker.tsx
+++ b/app/_components/CourseSubjectPicker.tsx
@@ -86,7 +86,7 @@ export default function CourseSubjectPicker({
     <div className="space-y-3">
       <label className="block text-sm font-medium">Corso di Laurea</label>
       <select
-        className="w-full rounded-xl border px-3 py-3"
+        className="w-full rounded-xl border px-3 py-3 relative z-20 pointer-events-auto"
         value={courseId}
         onChange={(e) => setCourseId(e.target.value)}
         disabled={loadingCourses}
@@ -108,7 +108,7 @@ export default function CourseSubjectPicker({
 
       <label className="block text-sm font-medium">Materia</label>
       <select
-        className="w-full rounded-xl border px-3 py-3"
+        className="w-full rounded-xl border px-3 py-3 relative z-20 pointer-events-auto"
         value={subjectId}
         onChange={(e) => setSubjectId(e.target.value)}
         disabled={!courseId || loadingSubjects}


### PR DESCRIPTION
## Summary
- ensure course/subject picker card receives pointer events
- prevent decorative Buddy and background overlays from intercepting clicks
- allow selects to receive pointer events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6171551883328546af8a8b84de23