### PR TITLE
refactor: lazily create Supabase admin client for API routes

### DIFF
--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -1,19 +1,20 @@
 import { NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase-server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic'; // evita pre-render/valutazione statica
 
 export async function GET() {
-  const { data, error } = await supabaseAdmin
-    .from('courses')
-    .select('id,name')
-    .order('name', { ascending: true });
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id,name')
+      .order('name', { ascending: true });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, {
-      status: 500,
-      headers: { 'Cache-Control': 'no-store' },
-    });
+    if (error) throw error;
+    return NextResponse.json(data ?? [], { headers: { 'Cache-Control': 'no-store' } });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message ?? e) }, { status: 500 });
   }
-  return NextResponse.json(data ?? [], { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/app/api/subjects/route.ts
+++ b/app/api/subjects/route.ts
@@ -1,26 +1,25 @@
 import { NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase-server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const course = searchParams.get('course');
-  if (!course) {
-    return NextResponse.json([], { headers: { 'Cache-Control': 'no-store' } });
-  }
+  try {
+    const { searchParams } = new URL(req.url);
+    const course = searchParams.get('course');
+    if (!course) return NextResponse.json([], { headers: { 'Cache-Control': 'no-store' } });
 
-  const { data, error } = await supabaseAdmin
-    .from('subjects')
-    .select('id,name,course_id')
-    .eq('course_id', course)
-    .order('name', { ascending: true });
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .from('subjects')
+      .select('id,name,course_id')
+      .eq('course_id', course)
+      .order('name', { ascending: true });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, {
-      status: 500,
-      headers: { 'Cache-Control': 'no-store' },
-    });
+    if (error) throw error;
+    return NextResponse.json(data ?? [], { headers: { 'Cache-Control': 'no-store' } });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message ?? e) }, { status: 500 });
   }
-  return NextResponse.json(data ?? [], { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,8 +1,22 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+let _admin: SupabaseClient | null = null;
 
-export const supabaseAdmin = createClient(url, serviceKey, {
-  auth: { autoRefreshToken: false, persistSession: false },
-});
+export function getSupabaseAdmin(): SupabaseClient {
+  if (_admin) return _admin;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceKey) {
+    // NON lanciare al top-level: lancia solo quando qualcuno prova a usarlo.
+    throw new Error(
+      'Missing env: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'
+    );
+  }
+
+  _admin = createClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  return _admin;
+}


### PR DESCRIPTION
## Summary
- lazy-initialize Supabase admin client with runtime env checks
- load Supabase client inside courses and subjects API handlers
- mark courses and subjects routes as force-dynamic to avoid pre-render errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config; aborted)


------
https://chatgpt.com/codex/tasks/task_e_68ab6c7e7834833295835ce9d6cacb28